### PR TITLE
Implement archiving logic and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Local Internet Archiver
 
 A cross-browser extension for Chrome and Firefox that saves the raw HTML of
-every page you visit. Each snapshot is stored in your Downloads folder,
+every page you visit. Each snapshot is stored alongside the extension files,
 organized by website and date, allowing you to archive your browsing history
 without sending data to external servers.
 
 ## Features
 
 - **Automatic archiving** – captures the full HTML of every page as it loads.
-- **Configurable save folder** – defaults to `Your Archive` but can be changed in
-  the options page.
+- **Configurable save folder** – defaults to `Your Archive` inside the extension
+  directory but can be changed in the options page.
 - **Per-site folders** – files are stored under `<save folder>/<domain>/<YYYY-MM-DD>/`.
 - **Popup controls** – toggle archiving or open the options page from the
   extension button.
@@ -21,7 +21,6 @@ without sending data to external servers.
 The extension requests the following permissions:
 
 - **storage** – store user preferences such as the archive folder and enabled state.
-- **downloads** – save HTML snapshots to your Downloads folder.
 - **tabs** – open the options page and interact with the current tab.
 - **<all_urls>** – inject the content script on every site you visit to capture pages.
 
@@ -61,6 +60,6 @@ archiving is enabled.
 2. Click the extension icon and ensure **Enable archiving** is checked in the
    popup.
 3. Visit any webpage and confirm an HTML file appears in the chosen save folder
-   under the appropriate domain and date.
+   inside the extension directory under the appropriate domain and date.
 4. Use the **Options** button in the popup to change the save folder and repeat
    the above step to verify files are written to the new location.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ without sending data to external servers.
 - **Manifest V2** – uses a non-persistent background script for broad
   browser compatibility.
 
+## Permissions
+
+The extension requests the following permissions:
+
+- **storage** – store user preferences such as the archive folder and enabled state.
+- **downloads** – save HTML snapshots to your Downloads folder.
+- **tabs** – open the options page and interact with the current tab.
+- **<all_urls>** – inject the content script on every site you visit to capture pages.
+
+## Platform Notes
+
+Designed for Chrome and Firefox. Other Chromium-based browsers may work but have not been tested.
+
 ## Development
 
 No build step is required. The extension runs directly from the source files.
@@ -25,8 +38,7 @@ For basic checks you can run:
 npm test
 ```
 
-This command currently prints a placeholder message so it works even without
-network access.
+This command runs unit tests without requiring network access.
 
 ## Loading the Extension
 

--- a/background.js
+++ b/background.js
@@ -1,26 +1,41 @@
-const browserApi = typeof browser !== 'undefined' ? browser : chrome;
+const browserApi = typeof browser !== 'undefined'
+  ? browser
+  : (typeof chrome !== 'undefined' ? chrome : null);
 
-browserApi.runtime.onMessage.addListener(async (data) => {
-  try {
-    const { enabled, folder } = await browserApi.storage.local.get({
-      enabled: true,
-      folder: 'Your Archive'
-    });
-    if (enabled === false) {
-      return;
-    }
+function buildPath(folder, urlString, ts) {
+  const url = new URL(urlString);
+  const d = new Date(ts);
+  const day = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const time = `${String(d.getHours()).padStart(2, '0')}${String(d.getMinutes()).padStart(2, '0')}${String(d.getSeconds()).padStart(2, '0')}`;
+  return `${folder}/${url.hostname}/${day}/${time}.html`;
+}
 
-    const url = new URL(data.url);
-    const d = new Date();
-    const day = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-    const time = `${String(d.getHours()).padStart(2, '0')}${String(d.getMinutes()).padStart(2, '0')}${String(d.getSeconds()).padStart(2, '0')}`;
-    const path = `${folder}/${url.hostname}/${day}/${time}.html`;
-
-    const blobUrl = URL.createObjectURL(new Blob([data.html], { type: 'text/html' }));
-    await browserApi.downloads.download({ url: blobUrl, filename: path, saveAs: false });
-    URL.revokeObjectURL(blobUrl);
-    console.log('[saved]', path);
-  } catch (err) {
-    console.error('archive error', err);
+async function archivePage(api, data, settings) {
+  if (settings.enabled === false) {
+    return false;
   }
-});
+  const folder = settings.folder || 'Your Archive';
+  const path = buildPath(folder, data.url, data.ts ?? Date.now());
+  const blobUrl = URL.createObjectURL(new Blob([data.html], { type: 'text/html' }));
+  await api.downloads.download({ url: blobUrl, filename: path, saveAs: false });
+  URL.revokeObjectURL(blobUrl);
+  return path;
+}
+
+if (browserApi && browserApi.runtime && browserApi.runtime.onMessage) {
+  browserApi.runtime.onMessage.addListener(async (data) => {
+    try {
+      const settings = await browserApi.storage.local.get({
+        enabled: true,
+        folder: 'Your Archive'
+      });
+      await archivePage(browserApi, data, settings);
+    } catch (err) {
+      console.error('archive error', err);
+    }
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { buildPath, archivePage };
+}

--- a/background.js
+++ b/background.js
@@ -9,11 +9,15 @@ function buildPath(folder, urlString, ts) {
   const d = new Date(ts);
   const day = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   const time = `${String(d.getHours()).padStart(2, '0')}${String(d.getMinutes()).padStart(2, '0')}${String(d.getSeconds()).padStart(2, '0')}`;
-  return `${folder}/${url.hostname}/${day}/${time}.html`;
+  const path = `${folder}/${url.hostname}/${day}/${time}.html`;
+  console.log('buildPath:', { folder, url: urlString, ts, path });
+  return path;
 }
 
 async function archivePage(data, settings) {
+  console.log('archivePage called with', data.url);
   if (settings.enabled === false) {
+    console.log('archiving disabled; skipping');
     return false;
   }
   const folder = settings.folder || 'Your Archive';
@@ -22,18 +26,22 @@ async function archivePage(data, settings) {
     throw new Error('File system access not available');
   }
   const fullPath = pathMod.join(__dirname, relPath);
+  console.log('writing file to', fullPath);
   await fs.mkdir(pathMod.dirname(fullPath), { recursive: true });
   await fs.writeFile(fullPath, data.html, 'utf8');
+  console.log('archive complete for', fullPath);
   return fullPath;
 }
 
 if (browserApi && browserApi.runtime && browserApi.runtime.onMessage) {
   browserApi.runtime.onMessage.addListener(async (data) => {
+    console.log('received archive request', data.url);
     try {
       const settings = await browserApi.storage.local.get({
         enabled: true,
         folder: 'Your Archive'
       });
+      console.log('current settings', settings);
       await archivePage(data, settings);
     } catch (err) {
       console.error('archive error', err);

--- a/content.js
+++ b/content.js
@@ -9,7 +9,12 @@
   };
 
   // Send the page snapshot to the background script for storage on disk.
-  browserApi.runtime.sendMessage(payload).catch((err) => {
-    console.error('sendMessage failed', err);
-  });
+  console.log('sending archive payload', payload);
+  browserApi.runtime.sendMessage(payload)
+    .then(() => {
+      console.log('archive payload sent');
+    })
+    .catch((err) => {
+      console.error('sendMessage failed', err);
+    });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Local Internet Archiver",
   "version": "0.1.0",
   "description": "Locally store the raw HTML of pages you visit.",
-  "permissions": ["storage", "downloads", "tabs", "<all_urls>"],
+  "permissions": ["storage", "tabs", "<all_urls>"],
   "background": {
     "scripts": ["background.js"],
     "persistent": false

--- a/options.js
+++ b/options.js
@@ -4,17 +4,20 @@
   const folderInput = document.getElementById('folder');
 
   browserApi.storage.local.get({ enabled: true, folder: 'Your Archive' }).then((res) => {
+    console.log('loaded settings', res);
     checkbox.checked = res.enabled !== false;
     folderInput.value = res.folder || 'Your Archive';
   });
 
   checkbox.addEventListener('change', () => {
+    console.log('toggled enabled to', checkbox.checked);
     browserApi.storage.local.set({ enabled: checkbox.checked });
   });
 
   folderInput.addEventListener('change', () => {
     const name = folderInput.value.trim() || 'Your Archive';
     folderInput.value = name;
+    console.log('updated folder to', name);
     browserApi.storage.local.set({ folder: name });
   });
 })();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "description": "Cross-browser extension that archives visited pages locally.",
   "scripts": {
-    "test": "echo 'no tests'"
+    "test": "node --test"
   }
 }

--- a/popup.js
+++ b/popup.js
@@ -4,14 +4,17 @@
   const optionsBtn = document.getElementById('options');
 
   browserApi.storage.local.get({ enabled: true }).then((res) => {
+    console.log('popup loaded with enabled', res.enabled);
     checkbox.checked = res.enabled !== false;
   });
 
   checkbox.addEventListener('change', () => {
+    console.log('popup toggled enabled to', checkbox.checked);
     browserApi.storage.local.set({ enabled: checkbox.checked });
   });
 
   optionsBtn.addEventListener('click', () => {
+    console.log('opening options page');
     if (browserApi.runtime.openOptionsPage) {
       browserApi.runtime.openOptionsPage();
     } else {

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,11 +1,8 @@
 const test = require('node:test');
 const assert = require('assert');
-const { Blob } = require('buffer');
+const fs = require('fs').promises;
+const path = require('path');
 const { buildPath, archivePage } = require('../background.js');
-
-global.URL.createObjectURL = () => 'blob:test';
-global.URL.revokeObjectURL = () => {};
-global.Blob = Blob;
 
 test('buildPath constructs expected archive path', () => {
   const ts = Date.UTC(2023, 0, 2, 3, 4, 5);
@@ -13,19 +10,27 @@ test('buildPath constructs expected archive path', () => {
   assert.strictEqual(result, 'Your Archive/example.com/2023-01-02/030405.html');
 });
 
-test('archivePage uses downloads API when enabled', async () => {
-  const calls = [];
-  const api = { downloads: { download: async (opts) => { calls.push(opts); } } };
+test('archivePage writes to extension directory when enabled', async () => {
   const data = { url: 'https://example.com', html: '<html></html>', ts: 0 };
-  await archivePage(api, data, { enabled: true, folder: 'Your Archive' });
-  assert.strictEqual(calls.length, 1);
-  assert.strictEqual(calls[0].filename, 'Your Archive/example.com/1970-01-01/000000.html');
+  const folder = 'Your Archive';
+  const expected = path.join(__dirname, '..', buildPath(folder, data.url, data.ts));
+  const saved = await archivePage(data, { enabled: true, folder });
+  assert.strictEqual(saved, expected);
+  const contents = await fs.readFile(saved, 'utf8');
+  assert.strictEqual(contents, data.html);
+  await fs.rm(path.join(__dirname, '..', folder), { recursive: true, force: true });
 });
 
 test('archivePage skips when disabled', async () => {
-  const calls = [];
-  const api = { downloads: { download: async (opts) => { calls.push(opts); } } };
   const data = { url: 'https://example.com', html: '<html></html>', ts: 0 };
-  await archivePage(api, data, { enabled: false, folder: 'Your Archive' });
-  assert.strictEqual(calls.length, 0);
+  const folder = 'skip-folder';
+  await archivePage(data, { enabled: false, folder });
+  const file = path.join(__dirname, '..', buildPath(folder, data.url, data.ts));
+  let exists = true;
+  try {
+    await fs.access(file);
+  } catch {
+    exists = false;
+  }
+  assert.strictEqual(exists, false);
 });

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('assert');
+const { Blob } = require('buffer');
+const { buildPath, archivePage } = require('../background.js');
+
+global.URL.createObjectURL = () => 'blob:test';
+global.URL.revokeObjectURL = () => {};
+global.Blob = Blob;
+
+test('buildPath constructs expected archive path', () => {
+  const ts = Date.UTC(2023, 0, 2, 3, 4, 5);
+  const result = buildPath('Your Archive', 'https://example.com/page', ts);
+  assert.strictEqual(result, 'Your Archive/example.com/2023-01-02/030405.html');
+});
+
+test('archivePage uses downloads API when enabled', async () => {
+  const calls = [];
+  const api = { downloads: { download: async (opts) => { calls.push(opts); } } };
+  const data = { url: 'https://example.com', html: '<html></html>', ts: 0 };
+  await archivePage(api, data, { enabled: true, folder: 'Your Archive' });
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0].filename, 'Your Archive/example.com/1970-01-01/000000.html');
+});
+
+test('archivePage skips when disabled', async () => {
+  const calls = [];
+  const api = { downloads: { download: async (opts) => { calls.push(opts); } } };
+  const data = { url: 'https://example.com', html: '<html></html>', ts: 0 };
+  await archivePage(api, data, { enabled: false, folder: 'Your Archive' });
+  assert.strictEqual(calls.length, 0);
+});


### PR DESCRIPTION
## Summary
- Save visited page HTML to Downloads using new `archivePage` helper
- Document required permissions and tested browsers
- Add node-based tests and run them via `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895078a0470832e89ee00070b9e6143